### PR TITLE
Add readonly property to textbox

### DIFF
--- a/src/SKUI/js/ui.textbox.js
+++ b/src/SKUI/js/ui.textbox.js
@@ -51,3 +51,10 @@ Textbox.prototype.set_value = function( value ) {
   $textbox.val( value );
   return value;
 };
+
+Textbox.prototype.set_readonly = function( value ) {
+  $textbox = this.control.children('input,textarea');
+  $textbox.prop( 'readonly', value );
+  return value;
+};
+

--- a/src/SKUI/textbox.rb
+++ b/src/SKUI/textbox.rb
@@ -14,6 +14,10 @@ module SKUI
     # @since 1.0.0
     prop_bool( :multiline, &TypeCheck::BOOLEAN )
 
+    # @return [Boolean]
+    # @since 1.0.0
+    prop_bool( :readonly, &TypeCheck::BOOLEAN )
+
     # @since 1.0.0
     define_event( :change )
     define_event( :textchange )


### PR DESCRIPTION
Adds the ability to (temporarily) lock the contents of the textbox.
I use this to create a readonly progress/log-window...