### PR TITLE
Added custom css class identifier

### DIFF
--- a/src/SKUI/control.rb
+++ b/src/SKUI/control.rb
@@ -47,6 +47,10 @@ module SKUI
     # @since 1.0.0
     prop_writer( :font_name, :font_size ) # (!) Needs more work.
 
+    # @return [String]
+    # @since 1.0.0
+    prop( :css_class, &TypeCheck::STRING )
+
     # @return [Rect]
     # @since 1.0.0
     attr_reader( :rect )
@@ -55,6 +59,14 @@ module SKUI
     def initialize
       super()
       @rect = Rect.new( self )
+    end
+
+    # Set a custom css class identifier for this control
+    # @since 1.0.0
+    def css_class( css_class )
+      if css_class.is_a? String
+        @properties[ :css_class ] = css_class
+      end
     end
 
     # Positive `x` value will anchor the control to the left side of the

--- a/src/SKUI/js/ui.control.js
+++ b/src/SKUI/js/ui.control.js
@@ -12,6 +12,11 @@ function Control( jquery_element ) {
   Base.call( this, jquery_element );
 }
 
+Control.prototype.set_css_class = function( value ) {
+  this.control.addClass( value );
+  return value;
+};
+
 Control.prototype.set_disabled = function( value ) {
   this.control.toggleClass( 'disabled', value );
   this.control.prop( 'disabled', value );


### PR DESCRIPTION
Gives the option to add specific styling to each control

Feel free to reject this pull request if it's not in line with your ideas for SKUI.
I wanted additional css-classes in my theme-stylesheet with specific formatting for some controls and I couldn't find a built-in method to accomplish this.
